### PR TITLE
Remove useless frame setting

### DIFF
--- a/Source/SwiftySKScrollView.swift
+++ b/Source/SwiftySKScrollView.swift
@@ -83,7 +83,6 @@ public class SwiftySKScrollView: UIScrollView {
         }
 
         backgroundColor = .clear
-        self.frame = frame
         delegate = self
         indicatorStyle = .white
         isScrollEnabled = true


### PR DESCRIPTION
The frame is already set by calling  `super.init(frame: frame)` above. 
It makes no sense to set the same value again. 👍 